### PR TITLE
Bug 1

### DIFF
--- a/src/parray_gin.c
+++ b/src/parray_gin.c
@@ -645,6 +645,7 @@ parray_gin_extract_query(PG_FUNCTION_ARGS)
 	bool	  **pmatch = (bool **) PG_GETARG_POINTER(3);
 	Pointer   **extra_data = (Pointer **) PG_GETARG_POINTER(4);
 	bool	  **nullFlags = (bool **) PG_GETARG_POINTER(5);
+	int32     *searchMode = (int32 *) PG_GETARG_POINTER(6);
 
 	Datum	   *keys;
 	bool		is_partial;
@@ -670,6 +671,12 @@ parray_gin_extract_query(PG_FUNCTION_ARGS)
 											 PointerGetDatum(extra_data));
 	*nullFlags = NULL;
 	*pmatch = NULL;
+
+	/*
+	 * If no trigram was extracted then we have to scan all the index.
+	 */
+	if (*nkeys == 0)
+		*searchMode = GIN_SEARCH_MODE_ALL;
 
 	PG_RETURN_POINTER(keys);
 }

--- a/src/trgm.c
+++ b/src/trgm.c
@@ -10,6 +10,9 @@
 #include "catalog/pg_type.h"
 #include "tsearch/ts_locale.h"
 
+#if PG_VERSION_NUM >= 90500
+#include "utils/pg_crc.h"
+#endif
 
 float4		trgm_limit = 0.3f;
 
@@ -119,9 +122,15 @@ cnt_trigram(trgm *tptr, char *str, int bytelen)
 	{
 		pg_crc32	crc;
 
+#if PG_VERSION_NUM >= 90500
+		INIT_LEGACY_CRC32(crc);
+		COMP_LEGACY_CRC32(crc, str, bytelen);
+		FIN_LEGACY_CRC32(crc);
+#else
 		INIT_CRC32(crc);
 		COMP_CRC32(crc, str, bytelen);
 		FIN_CRC32(crc);
+#endif
 
 		/*
 		 * use only 3 upper bytes from crc, hope, it's good enough hashing

--- a/test/expected/index.out
+++ b/test/expected/index.out
@@ -71,7 +71,7 @@ select count(*) from test_table where val @> array['%'];
 0
 -- 0
 select count(*) from test_table where val @@> array['%'];
-0
+32
 -- 3
 select count(*) from test_table where val <@ array['foo4', 'bar4', 'baz4'];
 3


### PR DESCRIPTION
When the query contains no extractable trigrams, need to scan the whole index
